### PR TITLE
remove Netherlands Antilles which dont exist since 2010

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -896,12 +896,6 @@ export const codes: ICountryCodeItem[] = [
     isoCode3: 'NLD',
   },
   {
-    country: 'Netherlands Antilles',
-    countryCodes: ['599'],
-    isoCode2: 'AN',
-    isoCode3: 'ANT',
-  },
-  {
     country: 'New Caledonia',
     countryCodes: ['687'],
     isoCode2: 'NC',


### PR DESCRIPTION
@joonhocho I am using your library in my react project, and I used it in select. 

Before to fed countries to select I translated it via browser's [Intl.DisplayNames](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DisplayNames)

And it appeared that it gives both for Curacao ( isoCode2: 'CW' ) and Netherlands Antilles ( isoCode2: 'AN') the same display name which broke my react select.

It seems that  Netherlands Antilles doesn't exist since 2010